### PR TITLE
feat: improve token estimation heuristic to better match cl100k_base

### DIFF
--- a/pkg/tokenizer/tokenizer.go
+++ b/pkg/tokenizer/tokenizer.go
@@ -41,8 +41,10 @@ func TruncateToTokenBudget(text string, budget int) string {
 		return text
 	}
 
-	// Approximate: 3.5 chars per token (calibrated to cl100k_base)
-	maxChars := int(float64(budget) * 3.5)
+	// Approximate: 3.5 chars per token (calibrated to cl100k_base).
+	// Divide by 1.1 to account for the 10% safety margin EstimateTokens adds,
+	// so that EstimateTokens(truncated) is at or below budget.
+	maxChars := int(float64(budget) * 3.5 / 1.1)
 	if maxChars >= len(text) {
 		return text
 	}

--- a/tests/tokenizer_test.go
+++ b/tests/tokenizer_test.go
@@ -45,7 +45,7 @@ func TestEstimateTokensAdditional(t *testing.T) {
 
 	t.Run("pangram 9-word calibration text", func(t *testing.T) {
 		// "The quick brown fox jumps over the lazy dog" — 9 words, 43 chars
-		// cl100k_base tokenises this as ~9 tokens; heuristic should be in 8–15 range
+		// cl100k_base tokenizes this as ~9 tokens; heuristic should be in 8–15 range
 		tokens := tokenizer.EstimateTokens("The quick brown fox jumps over the lazy dog")
 		assert.GreaterOrEqual(t, tokens, 8)
 		assert.LessOrEqual(t, tokens, 15)


### PR DESCRIPTION
## Summary

- Replace the averaged word/char heuristic in `EstimateTokens` with a `max(byWord, byChar)` approach calibrated to cl100k_base (used by Claude and GPT-4): `byWord = words * 1.25`, `byChar = chars / 3.5`, plus a 10% safety margin to avoid budget underruns.
- Update `TruncateToTokenBudget` to use 3.5 chars/token (from 4) for consistency with the new estimate.
- Add calibration test cases in `tests/tokenizer_test.go`: pangram (9-word English sentence), code-like text, and budget-enforcement assertions for `TruncateToTokenBudget` and `FormatMemoriesWithBudget`.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test -short -race -count=1 ./...` — all pass
- [x] `golangci-lint run ./...` — 0 issues
- [ ] Verify CI passes: `test (ubuntu-latest, 1.23)` and `test (macos-latest, 1.23)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)