### PR TITLE
fix(embedder): retry network errors in OpenAI client; add retry tests

### DIFF
--- a/internal/embedder/openai.go
+++ b/internal/embedder/openai.go
@@ -148,6 +148,17 @@ func (o *OpenAIEmbedder) embedBatch(ctx context.Context, texts []string) ([][]fl
 
 		resp, err = o.client.Do(req)
 		if err != nil {
+			if attempt < openAIMaxRetries-1 {
+				wait := time.Duration(1<<uint(attempt)) * time.Second
+				o.logger.Warn("openai: network error, retrying",
+					"attempt", attempt+1, "error", err, "wait", wait)
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				case <-time.After(wait):
+				}
+				continue
+			}
 			return nil, fmt.Errorf("openai embedder: calling API: %w", err)
 		}
 
@@ -238,3 +249,6 @@ func parseRetryAfter(header string, maxWait time.Duration) time.Duration {
 	}
 	return wait
 }
+
+// ParseRetryAfterForTest exposes parseRetryAfter for unit testing only.
+var ParseRetryAfterForTest = parseRetryAfter

--- a/tests/openai_embedder_test.go
+++ b/tests/openai_embedder_test.go
@@ -3,10 +3,13 @@ package tests
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -230,4 +233,91 @@ func TestOpenAIEmbedder_EmbedBatch_OrderPreserved(t *testing.T) {
 	assert.Equal(t, float32(0), vecs[0][0])
 	assert.Equal(t, float32(1), vecs[1][0])
 	assert.Equal(t, float32(2), vecs[2][0])
+}
+
+// TestOpenAIEmbedder_Embed_NetworkErrorRetried verifies that a TCP-level error
+// is retried and the embedder eventually succeeds on the third attempt.
+func TestOpenAIEmbedder_Embed_NetworkErrorRetried(t *testing.T) {
+	var callCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := callCount.Add(1)
+		if n < 3 {
+			// Close without writing a response to simulate a connection reset.
+			hj, ok := w.(http.Hijacker)
+			if !ok {
+				t.Error("server does not support hijacking")
+				return
+			}
+			conn, _, _ := hj.Hijack()
+			_ = conn.Close()
+			return
+		}
+		// Third call succeeds.
+		w.Header().Set("Content-Type", "application/json")
+		resp := map[string]any{
+			"data": []map[string]any{
+				{"embedding": make([]float32, 768), "index": 0},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	emb := embedder.NewOpenAIEmbedderWithURL(srv.URL+"/v1/embeddings", "test-key", "", 768, logger)
+	vec, err := emb.Embed(context.Background(), "hello")
+	require.NoError(t, err)
+	require.Len(t, vec, 768)
+	assert.Equal(t, int32(3), callCount.Load(), "expected 3 calls: 2 network failures + 1 success")
+}
+
+// TestOpenAIEmbedder_Embed_429ThenSuccess verifies that a 429 with Retry-After
+// is honored and the embedder succeeds on the second attempt.
+func TestOpenAIEmbedder_Embed_429ThenSuccess(t *testing.T) {
+	var callCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := callCount.Add(1)
+		if n == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		resp := map[string]any{
+			"data": []map[string]any{
+				{"embedding": make([]float32, 768), "index": 0},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	emb := embedder.NewOpenAIEmbedderWithURL(srv.URL+"/v1/embeddings", "test-key", "", 768, logger)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	vec, err := emb.Embed(ctx, "hello")
+	require.NoError(t, err)
+	require.Len(t, vec, 768)
+	assert.Equal(t, int32(2), callCount.Load(), "expected 2 calls: 1 rate-limit + 1 success")
+}
+
+// TestParseRetryAfter verifies edge cases in the Retry-After header parser.
+func TestParseRetryAfter(t *testing.T) {
+	max := 60 * time.Second
+	cases := []struct {
+		header string
+		want   time.Duration
+	}{
+		{"5", 5 * time.Second},
+		{"120", max},         // capped at max
+		{"0", time.Second},   // zero defaults to 1s
+		{"-1", time.Second},  // negative defaults to 1s
+		{"abc", time.Second}, // non-numeric defaults to 1s
+		{"", time.Second},    // empty defaults to 1s
+	}
+	for _, tc := range cases {
+		got := embedder.ParseRetryAfterForTest(tc.header, max)
+		assert.Equal(t, tc.want, got, "ParseRetryAfterForTest(%q)", tc.header)
+	}
 }


### PR DESCRIPTION
## Summary
- Retry TCP/TLS/DNS network errors in OpenAI embedder (previously only HTTP 429/5xx were retried)
- Export `parseRetryAfter` via `ParseRetryAfterForTest` for unit testing
- 3 new tests: network error retry, 429-then-success, parseRetryAfter edge cases

## Test plan
- [x] `go build ./...` passes
- [x] `go test -short -race -count=1 -run TestOpenAIEmbedder|TestParseRetryAfter ./tests/` passes
- [x] `golangci-lint run ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)