### PR TITLE
fix(import): increase JSONL scanner buffer to 10MB, report partial count on error

### DIFF
--- a/cmd/openclaw-cortex/cmd_import.go
+++ b/cmd/openclaw-cortex/cmd_import.go
@@ -14,6 +14,14 @@ import (
 	"github.com/ajitpratap0/openclaw-cortex/internal/models"
 )
 
+// newJSONLScanner returns a Scanner pre-configured with a 10 MB buffer
+// to handle large memory records that exceed the default 64KB limit.
+func newJSONLScanner(r io.Reader) *bufio.Scanner {
+	s := bufio.NewScanner(r)
+	s.Buffer(make([]byte, 1<<20), 10<<20) // initial 1MB, max 10MB
+	return s
+}
+
 func importCmd() *cobra.Command {
 	var (
 		filePath string
@@ -62,7 +70,7 @@ Use - as the file path to read from stdin.`,
 					memories = append(memories, m)
 				}
 			case "jsonl":
-				scanner := bufio.NewScanner(r)
+				scanner := newJSONLScanner(r)
 				for scanner.Scan() {
 					line := strings.TrimSpace(scanner.Text())
 					if line == "" {
@@ -117,10 +125,12 @@ Use - as the file path to read from stdin.`,
 
 				vec, embedErr := emb.Embed(ctx, m.Content)
 				if embedErr != nil {
+					fmt.Printf("Import stopped after %d memories (%d skipped): %v\n", imported, skipped, embedErr)
 					return fmt.Errorf("import: embedding memory %q: %w", m.ID, embedErr)
 				}
 
 				if upsertErr := st.Upsert(ctx, *m, vec); upsertErr != nil {
+					fmt.Printf("Import stopped after %d memories (%d skipped): %v\n", imported, skipped, upsertErr)
 					return fmt.Errorf("import: upserting memory %q: %w", m.ID, upsertErr)
 				}
 

--- a/cmd/openclaw-cortex/import_test.go
+++ b/cmd/openclaw-cortex/import_test.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNewJSONLScanner_HandlesLargeLine(t *testing.T) {
+	// Verify the scanner can handle lines > 64KB (default limit).
+	largeContent := strings.Repeat("a", 100*1024) // 100KB
+	line := `{"id":"x","content":"` + largeContent + `","type":"fact","scope":"permanent","confidence":0.9}`
+	scanner := newJSONLScanner(strings.NewReader(line + "\n"))
+	if !scanner.Scan() {
+		t.Fatalf("scanner failed on 100KB line: %v", scanner.Err())
+	}
+	if scanner.Err() != nil {
+		t.Fatalf("unexpected error: %v", scanner.Err())
+	}
+}


### PR DESCRIPTION
## Summary
- Replaces `bufio.NewScanner(r)` with `newJSONLScanner(r)` helper that configures a 10MB max buffer — fixes silent `ErrTooLong` truncation on JSONL lines > 64KB
- Adds `fmt.Printf` before each error return in the upsert loop to show how many records were imported before failure

## Test plan
- [ ] `TestNewJSONLScanner_HandlesLargeLine` — verifies 100KB line scans without error (would fail against old 64KB default)
- [ ] `go test -short -race -count=1 ./...` passes
- [ ] `golangci-lint run ./cmd/openclaw-cortex/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)