### PR TITLE
fix(config): validate OpenAIDim/provider, docker needs:build, lifecycle vecs bounds check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,7 @@ jobs:
   docker:
     name: Docker
     runs-on: ubuntu-latest
+    needs: build
     steps:
       - uses: actions/checkout@v4
         with:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -221,6 +221,26 @@ func (c *Config) Validate() error {
 	if c.Embedder.Provider == "openai" && c.Embedder.OpenAIKey == "" {
 		return fmt.Errorf("embedder.openai_api_key must not be empty when provider is \"openai\"")
 	}
+
+	// Validate provider name.
+	switch c.Embedder.Provider {
+	case "ollama", "openai", "":
+		// valid
+	default:
+		return fmt.Errorf("embedder.provider must be \"ollama\" or \"openai\", got %q", c.Embedder.Provider)
+	}
+
+	// Validate OpenAI-specific fields when openai provider is selected.
+	if c.Embedder.Provider == "openai" {
+		if c.Embedder.OpenAIDim <= 0 {
+			return fmt.Errorf("embedder.openai_dimensions must be > 0 when provider is \"openai\"")
+		}
+		if int(c.Memory.VectorDimension) != c.Embedder.OpenAIDim {
+			return fmt.Errorf("embedder.openai_dimensions (%d) must match memory.vector_dimension (%d)",
+				c.Embedder.OpenAIDim, c.Memory.VectorDimension)
+		}
+	}
+
 	return nil
 }
 

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -224,6 +224,10 @@ func (m *Manager) consolidate(ctx context.Context, dryRun bool) (int, error) {
 	if batchErr != nil {
 		return 0, fmt.Errorf("consolidate: batch embed failed: %w", batchErr)
 	}
+	if len(vecs) != len(memories) {
+		return 0, fmt.Errorf("consolidate: embedder returned %d vectors for %d memories (contract violation)",
+			len(vecs), len(memories))
+	}
 
 	consolidated := 0
 	deleted := make(map[string]bool)

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -217,3 +217,58 @@ func TestConfigClaudeStringShortKey(t *testing.T) {
 	s := cfg.String()
 	assert.Contains(t, s, "***")
 }
+
+func validBaseConfig() config.Config {
+	return config.Config{
+		Qdrant: config.QdrantConfig{Host: "localhost", Collection: "test"},
+		Ollama: config.OllamaConfig{BaseURL: "http://localhost:11434"},
+		Memory: config.MemoryConfig{
+			ChunkSize:       512,
+			ChunkOverlap:    64,
+			DedupThreshold:  0.92,
+			VectorDimension: 768,
+			DefaultTTLHours: 720,
+		},
+	}
+}
+
+func TestConfig_Validate_UnknownProvider(t *testing.T) {
+	cfg := validBaseConfig()
+	cfg.Embedder.Provider = "gemini"
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected error for unknown provider 'gemini'")
+	}
+}
+
+func TestConfig_Validate_OpenAIDimZero(t *testing.T) {
+	cfg := validBaseConfig()
+	cfg.Embedder.Provider = "openai"
+	cfg.Embedder.OpenAIKey = "sk-test"
+	cfg.Embedder.OpenAIDim = 0
+	cfg.Memory.VectorDimension = 768
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected error for OpenAIDim=0")
+	}
+}
+
+func TestConfig_Validate_OpenAIDimMismatch(t *testing.T) {
+	cfg := validBaseConfig()
+	cfg.Embedder.Provider = "openai"
+	cfg.Embedder.OpenAIKey = "sk-test"
+	cfg.Embedder.OpenAIDim = 512
+	cfg.Memory.VectorDimension = 768
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected error when OpenAIDim doesn't match VectorDimension")
+	}
+}
+
+func TestConfig_Validate_OpenAI_Valid(t *testing.T) {
+	cfg := validBaseConfig()
+	cfg.Embedder.Provider = "openai"
+	cfg.Embedder.OpenAIKey = "sk-test"
+	cfg.Embedder.OpenAIDim = 768
+	cfg.Memory.VectorDimension = 768
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected valid config, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- `config.Validate()` now rejects unknown `Provider` values and checks `OpenAIDim > 0` and `OpenAIDim == VectorDimension` when provider is `"openai"`
- `.github/workflows/release.yml`: `docker:` job gains `needs: build` so Docker images are only published after CI passes
- `lifecycle.go`: bounds check after `EmbedBatch` — returns error if embedder returns wrong vector count instead of panicking

## Test plan
- [ ] `TestConfig_Validate_UnknownProvider` — provider `"gemini"` must error
- [ ] `TestConfig_Validate_OpenAIDimZero` — zero dim with openai provider must error
- [ ] `TestConfig_Validate_OpenAIDimMismatch` — mismatched dims must error
- [ ] `TestConfig_Validate_OpenAI_Valid` — matching dims with valid key must pass
- [ ] `go test -short -race -count=1 ./...` passes
- [ ] `golangci-lint run ./internal/config/... ./internal/lifecycle/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)