### PR TITLE
fix(api): cap handleSearch limit to 1000, validate confidence [0,1], return 400 for invalid list limit

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -5,9 +5,9 @@ import (
 	"crypto/subtle"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -295,6 +295,10 @@ func (s *Server) handleUpdate(w http.ResponseWriter, r *http.Request) {
 		mem.Project = *req.Project
 	}
 	if req.Confidence != nil {
+		if *req.Confidence < 0 || *req.Confidence > 1 {
+			s.writeError(w, http.StatusBadRequest, "confidence must be between 0.0 and 1.0")
+			return
+		}
 		mem.Confidence = *req.Confidence
 	}
 	if req.Tags != nil {
@@ -376,13 +380,16 @@ func (s *Server) handleList(w http.ResponseWriter, r *http.Request) {
 	limitStr := q.Get("limit")
 	var limit uint64 = 100
 	if limitStr != "" {
-		var parsed uint64
-		if _, scanErr := fmt.Sscanf(limitStr, "%d", &parsed); scanErr == nil && parsed > 0 {
+		parsed, parseErr := strconv.ParseUint(limitStr, 10, 64)
+		if parseErr != nil || parsed == 0 {
+			s.writeError(w, http.StatusBadRequest, "limit must be a positive integer")
+			return
+		}
+		if parsed > maxListLimit {
+			limit = maxListLimit
+		} else {
 			limit = parsed
 		}
-	}
-	if limit > maxListLimit {
-		limit = maxListLimit
 	}
 
 	cursor := q.Get("cursor")
@@ -469,8 +476,12 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 		s.writeError(w, http.StatusBadRequest, "message is required")
 		return
 	}
+	const maxSearchLimit = 1000
 	if req.Limit <= 0 {
 		req.Limit = 10
+	}
+	if req.Limit > maxSearchLimit {
+		req.Limit = maxSearchLimit
 	}
 
 	vec, err := s.embedder.Embed(r.Context(), req.Message)

--- a/tests/api_test.go
+++ b/tests/api_test.go
@@ -427,6 +427,46 @@ func TestAPI_Search_MissingMessage(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 }
 
+// TestAPISearch_LimitCapped verifies that an absurdly large search limit is
+// silently capped to 1000 rather than blowing up.
+func TestAPISearch_LimitCapped(t *testing.T) {
+	ts, st := newTestServer(t, "")
+
+	now := time.Now().UTC()
+	mem := models.Memory{
+		ID:           "search-cap-001",
+		Type:         models.MemoryTypeFact,
+		Scope:        models.ScopePermanent,
+		Visibility:   models.VisibilityPrivate,
+		Content:      "capped limit test memory",
+		Confidence:   0.9,
+		Source:       "test",
+		CreatedAt:    now,
+		UpdatedAt:    now,
+		LastAccessed: now,
+	}
+	vec := make([]float32, 768)
+	for i := range vec {
+		vec[i] = 0.1
+	}
+	require.NoError(t, st.Upsert(context.Background(), mem, vec))
+
+	body := jsonBody(t, map[string]any{
+		"message": "test",
+		"limit":   9999999,
+	})
+	resp := doRequest(t, http.MethodPost, ts.URL+"/v1/search", body, "")
+	defer resp.Body.Close()
+
+	// The server should accept the request (not 400/500) and return results.
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var result map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
+	_, ok := result["results"]
+	assert.True(t, ok, "response should contain a results field")
+}
+
 // TestAPI_Remember_InvalidJSON verifies 400 for malformed JSON.
 func TestAPI_Remember_InvalidJSON(t *testing.T) {
 	ts, _ := newTestServer(t, "")

--- a/tests/crud_test.go
+++ b/tests/crud_test.go
@@ -761,6 +761,75 @@ func TestAPI_Search_ProjectFilter(t *testing.T) {
 
 // --- CLI update command ---
 
+// TestAPIPutMemory_ConfidenceOutOfRange verifies that PUT /v1/memories/{id}
+// returns 400 when confidence is outside the [0.0, 1.0] range.
+func TestAPIPutMemory_ConfidenceOutOfRange(t *testing.T) {
+	now := time.Now().UTC()
+
+	for _, tc := range []struct {
+		name       string
+		confidence float64
+	}{
+		{"negative", -0.5},
+		{"above-one", 1.5},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ts, st := newTestServer(t, "")
+
+			id := seedMemory(t, st, models.Memory{
+				ID:           "conf-range-" + tc.name,
+				Type:         models.MemoryTypeFact,
+				Scope:        models.ScopePermanent,
+				Visibility:   models.VisibilityPrivate,
+				Content:      "confidence range test",
+				Confidence:   0.8,
+				Source:       "test",
+				CreatedAt:    now,
+				UpdatedAt:    now,
+				LastAccessed: now,
+			})
+
+			body := jsonBody(t, map[string]any{
+				"confidence": tc.confidence,
+			})
+			resp := doRequest(t, http.MethodPut, ts.URL+"/v1/memories/"+id, body, "")
+			defer resp.Body.Close()
+
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+			var errResp map[string]string
+			require.NoError(t, json.NewDecoder(resp.Body).Decode(&errResp))
+			assert.NotEmpty(t, errResp["error"])
+		})
+	}
+}
+
+// TestAPIList_InvalidLimitReturns400 verifies that GET /v1/memories returns 400
+// for non-numeric or non-positive limit values.
+func TestAPIList_InvalidLimitReturns400(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		limit string
+	}{
+		{"alpha", "abc"},
+		{"negative", "-5"},
+		{"zero", "0"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ts, _ := newTestServer(t, "")
+
+			resp := doRequest(t, http.MethodGet, ts.URL+"/v1/memories?limit="+tc.limit, nil, "")
+			defer resp.Body.Close()
+
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+			var errResp map[string]string
+			require.NoError(t, json.NewDecoder(resp.Body).Decode(&errResp))
+			assert.NotEmpty(t, errResp["error"])
+		})
+	}
+}
+
 // TestCLI_Update_ContentFlag verifies that the update command stores new
 // content when --content is provided (using MockStore directly).
 func TestCLI_Update_ContentFlag(t *testing.T) {


### PR DESCRIPTION
## Summary
- `handleSearch`: adds `maxSearchLimit = 1000` constant and caps any `limit` value silently — prevents unbounded Qdrant queries
- `handleUpdate`: validates `confidence` is in `[0.0, 1.0]` before applying; returns `400` with descriptive message on out-of-range values
- `handleList`: replaces `fmt.Sscanf` with `strconv.ParseUint` — returns `400` for non-numeric, negative, or zero `limit` instead of silently falling back to default

## Test plan
- [ ] `TestAPISearch_LimitCapped` — limit 9999999 returns 200 (cap applied silently)
- [ ] `TestAPIPutMemory_ConfidenceOutOfRange` — confidence=-0.5 and 1.5 both return 400
- [ ] `TestAPIList_InvalidLimitReturns400` — limit=abc, -5, 0 all return 400
- [ ] `go test -short -race -count=1 ./...` passes
- [ ] `golangci-lint run ./internal/api/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)