### PR TITLE
fix(docs): grant gh-pages deploy permission and fix broken links

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,8 @@ on:
   workflow_dispatch:
 jobs:
   deploy:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -111,7 +111,7 @@ spec:
 
 ### Config File
 
-Place at `~/.openclaw-cortex/config.yaml`. See [README](../README.md#configuration) for full schema.
+Place at `~/.openclaw-cortex/config.yaml`. See [README](https://github.com/ajitpratap0/openclaw-cortex/blob/main/README.md#configuration) for full schema.
 
 ## Health Checks
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,7 +42,7 @@ cortex capture "Always prefer explicit error handling over panics" --type rule
 | Section | Description |
 |---------|-------------|
 | [Quickstart](quickstart.md) | End-to-end setup in 5 minutes |
-| [Architecture](architecture.md) | How the system works internally |
+| [Architecture](ARCHITECTURE.md) | How the system works internally |
 | [Claude Code Hooks](hooks.md) | Automatic memory injection for Claude Code |
 | [HTTP API](api.md) | REST API reference with request/response schemas |
 | [MCP Server](mcp.md) | Model Context Protocol integration for Claude Desktop |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -146,7 +146,7 @@ export OPENCLAW_CORTEX_OLLAMA_BASE_URL=http://my-ollama:11434
 
 ## Next Steps
 
-- [Architecture](architecture.md) — understand how recall scoring works
+- [Architecture](ARCHITECTURE.md) — understand how recall scoring works
 - [Claude Code Hooks](hooks.md) — automatic memory for every conversation
 - [HTTP API](api.md) — integrate with other tools
 - [MCP Server](mcp.md) — use from Claude Desktop


### PR DESCRIPTION
## Summary

- **Root cause of CI failure**: `docs.yml` deploy job was missing `permissions: contents: write` — `github-actions[bot]` was denied push access to `gh-pages` (403 error)
- Fix `architecture.md` → `ARCHITECTURE.md` links in `index.md` and `quickstart.md` (case-sensitive Linux filesystem; MkDocs nav uses uppercase)
- Replace `../README.md#configuration` in `DEPLOYMENT.md` with absolute GitHub URL (README is outside the MkDocs build tree)

## Test plan

- [ ] CI "Deploy Docs" workflow passes on merge to `main`
- [ ] No MkDocs link warnings for `architecture.md`, `DEPLOYMENT.md` on build
- [ ] Docs site renders Architecture page correctly from index and quickstart links

🤖 Generated with [Claude Code](https://claude.com/claude-code)