### PR TITLE
fix: wire entity upsert to Neo4j and strip code fences in entity extractor

### DIFF
--- a/cmd/openclaw-cortex/cmd_capture.go
+++ b/cmd/openclaw-cortex/cmd_capture.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -124,9 +125,24 @@ func captureCmd() *cobra.Command {
 				fmt.Printf("Captured [%s]: %s\n", mem.Type, truncate(cm.Content, 100))
 			}
 
-			// Entity extraction (graceful — skipped if no API key or on error)
+			// Initialize optional graph client (used for entity + fact writes to Neo4j).
+			var gc graphpkg.Client
+			if cfg.Graph.Enabled {
+				var gcErr error
+				gc, gcErr = newGraphClient(ctx, logger)
+				if gcErr != nil {
+					logger.Warn("graph client init failed, graph features disabled", "error", gcErr)
+				} else if gc != nil {
+					defer func() { _ = gc.Close() }()
+				}
+			}
+
+			// Entity extraction (graceful — skipped if no LLM or on error).
+			// entityNameToID maps lowercased entity names to their UUIDs so that
+			// the fact extractor (which returns names) can resolve to UUIDs.
 			var allEntityNames []string
-			if cfg.Claude.APIKey != "" {
+			entityNameToID := make(map[string]string)
+			if llmClient != nil {
 				extractor := capture.NewEntityExtractor(llmClient, cfg.Claude.Model, logger)
 				for i := range storedMems {
 					entities, extractErr := extractor.Extract(ctx, storedMems[i].content)
@@ -136,39 +152,54 @@ func captureCmd() *cobra.Command {
 					}
 					for j := range entities {
 						if upsertErr := st.UpsertEntity(ctx, entities[j]); upsertErr != nil {
-							logger.Warn("upsert entity failed", "entity", entities[j].Name, "error", upsertErr)
+							logger.Warn("upsert entity to qdrant failed", "entity", entities[j].Name, "error", upsertErr)
 							continue
 						}
 						if linkErr := st.LinkMemoryToEntity(ctx, entities[j].ID, storedMems[i].id); linkErr != nil {
 							logger.Warn("link entity to memory failed", "entity", entities[j].Name, "error", linkErr)
 						}
+						// Also upsert entity to Neo4j graph for relationship traversal.
+						if gc != nil {
+							if graphErr := gc.UpsertEntity(ctx, entities[j]); graphErr != nil {
+								logger.Warn("upsert entity to neo4j failed", "entity", entities[j].Name, "error", graphErr)
+							}
+						}
 						allEntityNames = append(allEntityNames, entities[j].Name)
+						entityNameToID[strings.ToLower(entities[j].Name)] = entities[j].ID
 					}
 				}
 			}
 
-			// Fact extraction + graph write (graceful — skipped if graph disabled or on error)
-			if cfg.Graph.Enabled && cfg.Claude.APIKey != "" && len(allEntityNames) > 0 {
-				gc, gcErr := newGraphClient(ctx, logger)
-				if gcErr != nil {
-					logger.Warn("graph client init failed, skipping fact extraction", "error", gcErr)
-				} else if gc != nil {
-					defer func() { _ = gc.Close() }()
-					factExtractor := graphpkg.NewFactExtractor(llmClient, cfg.Claude.Model, logger)
-					for i := range storedMems {
-						facts, factErr := factExtractor.Extract(ctx, storedMems[i].content, allEntityNames)
-						if factErr != nil {
-							logger.Warn("fact extraction failed, skipping", "error", factErr)
+			// Fact extraction + graph write (graceful — skipped if graph disabled or on error).
+			// The FactExtractor returns entity names in SourceEntityID/TargetEntityID;
+			// we resolve them to UUIDs via entityNameToID before upserting to Neo4j.
+			if gc != nil && llmClient != nil && len(allEntityNames) > 0 {
+				factExtractor := graphpkg.NewFactExtractor(llmClient, cfg.Claude.Model, logger)
+				for i := range storedMems {
+					facts, factErr := factExtractor.Extract(ctx, storedMems[i].content, allEntityNames)
+					if factErr != nil {
+						logger.Warn("fact extraction failed, skipping", "error", factErr)
+						continue
+					}
+					for j := range facts {
+						// Resolve entity names to UUIDs.
+						srcID, srcOK := entityNameToID[strings.ToLower(facts[j].SourceEntityID)]
+						tgtID, tgtOK := entityNameToID[strings.ToLower(facts[j].TargetEntityID)]
+						if !srcOK || !tgtOK {
+							logger.Warn("fact references unknown entity, skipping",
+								"source", facts[j].SourceEntityID, "target", facts[j].TargetEntityID,
+								"source_resolved", srcOK, "target_resolved", tgtOK)
 							continue
 						}
-						for j := range facts {
-							if upsertErr := gc.UpsertFact(ctx, facts[j]); upsertErr != nil {
-								logger.Warn("upsert fact failed", "fact_id", facts[j].ID, "error", upsertErr)
-								continue
-							}
-							if linkErr := gc.AppendMemoryToFact(ctx, facts[j].ID, storedMems[i].id); linkErr != nil {
-								logger.Warn("link fact to memory failed", "fact_id", facts[j].ID, "error", linkErr)
-							}
+						facts[j].SourceEntityID = srcID
+						facts[j].TargetEntityID = tgtID
+
+						if upsertErr := gc.UpsertFact(ctx, facts[j]); upsertErr != nil {
+							logger.Warn("upsert fact failed", "fact_id", facts[j].ID, "error", upsertErr)
+							continue
+						}
+						if linkErr := gc.AppendMemoryToFact(ctx, facts[j].ID, storedMems[i].id); linkErr != nil {
+							logger.Warn("link fact to memory failed", "fact_id", facts[j].ID, "error", linkErr)
 						}
 					}
 				}

--- a/cmd/openclaw-cortex/main.go
+++ b/cmd/openclaw-cortex/main.go
@@ -17,7 +17,7 @@ import (
 	"github.com/ajitpratap0/openclaw-cortex/internal/store"
 )
 
-var version = "0.5.0"
+var version = "0.6.0"
 
 var cfg *config.Config
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
     environment:
       NEO4J_AUTH: neo4j/openclaw-cortex
       NEO4J_PLUGINS: '[]'
+      NEO4J_server_jvm_additional: '--add-modules jdk.incubator.vector'
     volumes:
       - neo4j_data:/data
     restart: unless-stopped

--- a/extensions/openclaw-plugin/index.ts
+++ b/extensions/openclaw-plugin/index.ts
@@ -18,7 +18,7 @@ const execFileAsync = promisify(execFile);
 
 // Plugin version — bump this when making changes to the plugin.
 // The binary also has its own version (set via ldflags at build time).
-const PLUGIN_VERSION = "0.5.0";
+const PLUGIN_VERSION = "0.6.0";
 
 // ============================================================================
 // Types

--- a/extensions/openclaw-plugin/openclaw.plugin.json
+++ b/extensions/openclaw-plugin/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "memory-cortex",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "kind": "memory",
   "configSchema": {
     "type": "object",

--- a/extensions/openclaw-plugin/package.json
+++ b/extensions/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memory-cortex",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "OpenClaw memory plugin backed by Cortex (Qdrant vector DB + multi-factor ranking)",
   "type": "module",
   "main": "index.ts",

--- a/internal/capture/entity_extractor.go
+++ b/internal/capture/entity_extractor.go
@@ -81,6 +81,7 @@ func (e *EntityExtractor) Extract(ctx context.Context, content string) ([]models
 
 	e.logger.Debug("entity extraction response", "response", responseText)
 
+	responseText = llm.StripCodeFences(responseText)
 	var raw []capturedEntity
 	if jsonErr := json.Unmarshal([]byte(responseText), &raw); jsonErr != nil {
 		return nil, fmt.Errorf("entity extraction: parsing response: %w (raw: %s)", jsonErr, responseText)


### PR DESCRIPTION
## Summary

- Replace `cfg.Claude.APIKey != ""` guards with `llmClient != nil` in capture so entity/fact extraction works when using the OpenClaw gateway (no standalone API key)
- Upsert entities to **both** Qdrant (for vector search) and Neo4j (for graph traversal) — previously only went to Qdrant, so `UpsertFact` couldn't find entities
- Add `llm.StripCodeFences()` to entity extractor JSON parsing — gateway models wrap JSON in markdown fences
- Create graph client once before entity extraction loop instead of inside the fact extraction block

## Test plan

- [x] Tests pass (`go test -short -count=1 ./...`)
- [x] Capture with gateway produces entities in Neo4j (verified: Eve, Neo4j, TLS, Bolt nodes created)
- [x] Entity extraction parses correctly with code fence stripping

🤖 Generated with [Claude Code](https://claude.com/claude-code)