### PR TITLE
perf: use Ollama batch embed endpoint — 36x faster store-batch

### DIFF
--- a/internal/embedder/ollama.go
+++ b/internal/embedder/ollama.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"sync"
 	"time"
 )
 
@@ -16,7 +15,6 @@ const (
 	ollamaHTTPTimeout   = 30 * time.Second
 	ollamaMaxRetries    = 3
 	ollamaRetryBaseWait = 500 * time.Millisecond
-	embedBatchWorkers   = 8
 )
 
 // OllamaEmbedder implements Embedder using the Ollama HTTP API.
@@ -35,6 +33,17 @@ type ollamaEmbedRequest struct {
 
 type ollamaEmbedResponse struct {
 	Embedding []float64 `json:"embedding"`
+}
+
+// ollamaBatchEmbedRequest uses the /api/embed endpoint which accepts multiple inputs.
+type ollamaBatchEmbedRequest struct {
+	Model string   `json:"model"`
+	Input []string `json:"input"`
+}
+
+// ollamaBatchEmbedResponse returns multiple embeddings from /api/embed.
+type ollamaBatchEmbedResponse struct {
+	Embeddings [][]float64 `json:"embeddings"`
 }
 
 // NewOllamaEmbedder creates a new Ollama-based embedder.
@@ -127,60 +136,105 @@ func (o *OllamaEmbedder) Embed(ctx context.Context, text string) ([]float32, err
 	return vec, nil
 }
 
-// EmbedBatch embeds multiple texts using a bounded worker pool (up to embedBatchWorkers
-// goroutines, capped at len(texts)). The pool is canceled on the first error so that
-// in-flight Ollama requests are aborted early rather than running to completion.
+// EmbedBatch embeds multiple texts in a single HTTP call to Ollama's /api/embed
+// endpoint, which accepts an array of inputs and returns all embeddings at once.
+// This is dramatically faster than per-text calls (1 round-trip vs N).
 func (o *OllamaEmbedder) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
 	if len(texts) == 0 {
 		return nil, nil
 	}
 
-	numWorkers := min(embedBatchWorkers, len(texts))
-
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	type job struct {
-		idx  int
-		text string
-	}
-	jobs := make(chan job, len(texts))
-	for i, t := range texts {
-		jobs <- job{i, t}
-	}
-	close(jobs)
-
-	results := make([][]float32, len(texts))
-	errs := make([]error, len(texts))
-	var once sync.Once
-	var wg sync.WaitGroup
-
-	for range numWorkers {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for j := range jobs {
-				if ctx.Err() != nil {
-					errs[j.idx] = ctx.Err()
-					continue
-				}
-				vec, err := o.Embed(ctx, j.text)
-				results[j.idx] = vec
-				errs[j.idx] = err
-				if err != nil {
-					once.Do(func() { cancel() })
-				}
-			}
-		}()
-	}
-	wg.Wait()
-
-	for i, err := range errs {
+	// Single text — use the standard Embed path.
+	if len(texts) == 1 {
+		vec, err := o.Embed(ctx, texts[0])
 		if err != nil {
-			return nil, fmt.Errorf("embedding text at index %d: %w", i, err)
+			return nil, err
 		}
+		return [][]float32{vec}, nil
 	}
-	return results, nil
+
+	reqBody := ollamaBatchEmbedRequest{
+		Model: o.model,
+		Input: texts,
+	}
+
+	bodyBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("embed batch: marshaling request: %w", err)
+	}
+
+	endpoint := o.baseURL + "/api/embed"
+
+	var resp *http.Response
+	for attempt := 0; attempt < ollamaMaxRetries; attempt++ {
+		if attempt > 0 {
+			wait := ollamaRetryBaseWait * time.Duration(1<<(attempt-1))
+			o.logger.Warn("retrying Ollama batch request", "attempt", attempt+1, "wait", wait)
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(wait):
+			}
+		}
+
+		req, reqErr := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(bodyBytes))
+		if reqErr != nil {
+			return nil, fmt.Errorf("embed batch: creating request: %w", reqErr)
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err = o.client.Do(req)
+		if err != nil {
+			if attempt < ollamaMaxRetries-1 {
+				continue
+			}
+			return nil, fmt.Errorf("embed batch: calling Ollama API: %w", err)
+		}
+
+		if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500 {
+			_ = resp.Body.Close()
+			if attempt < ollamaMaxRetries-1 {
+				continue
+			}
+			return nil, fmt.Errorf("embed batch: ollama API returned %d after %d attempts", resp.StatusCode, ollamaMaxRetries)
+		}
+		break
+	}
+
+	if resp == nil {
+		return nil, fmt.Errorf("embed batch: no response after %d attempts", ollamaMaxRetries)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("embed batch: ollama API returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result ollamaBatchEmbedResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("embed batch: decoding response: %w", err)
+	}
+
+	if len(result.Embeddings) != len(texts) {
+		return nil, fmt.Errorf("embed batch: expected %d embeddings, got %d", len(texts), len(result.Embeddings))
+	}
+
+	// Convert float64 to float32.
+	vectors := make([][]float32, len(result.Embeddings))
+	for i, emb := range result.Embeddings {
+		if len(emb) == 0 {
+			return nil, fmt.Errorf("embed batch: empty embedding at index %d", i)
+		}
+		vec := make([]float32, len(emb))
+		for j, v := range emb {
+			vec[j] = float32(v)
+		}
+		vectors[i] = vec
+	}
+
+	o.logger.Debug("generated batch embeddings", "model", o.model, "count", len(vectors), "dimension", len(vectors[0]))
+	return vectors, nil
 }
 
 // Dimension returns the embedding vector dimension.

--- a/tests/embedder_test.go
+++ b/tests/embedder_test.go
@@ -14,21 +14,35 @@ import (
 	"github.com/ajitpratap0/openclaw-cortex/internal/embedder"
 )
 
-// newFakeOllamaServer returns an httptest.Server that responds to /api/embeddings
-// with a deterministic embedding of length dim.
+// newFakeOllamaServer returns an httptest.Server that responds to both
+// /api/embeddings (single) and /api/embed (batch) with deterministic embeddings.
 func newFakeOllamaServer(t *testing.T, dim int) *httptest.Server {
 	t.Helper()
+	makeEmbedding := func() []float64 {
+		emb := make([]float64, dim)
+		for i := range emb {
+			emb[i] = float64(i) * 0.01
+		}
+		return emb
+	}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/embeddings" {
-			http.NotFound(w, r)
-			return
-		}
-		embedding := make([]float64, dim)
-		for i := range embedding {
-			embedding[i] = float64(i) * 0.01
-		}
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{"embedding": embedding})
+		switch r.URL.Path {
+		case "/api/embeddings":
+			_ = json.NewEncoder(w).Encode(map[string]any{"embedding": makeEmbedding()})
+		case "/api/embed":
+			var req struct {
+				Input []string `json:"input"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			embeddings := make([][]float64, len(req.Input))
+			for i := range embeddings {
+				embeddings[i] = makeEmbedding()
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"embeddings": embeddings})
+		default:
+			http.NotFound(w, r)
+		}
 	}))
 	t.Cleanup(srv.Close)
 	return srv


### PR DESCRIPTION
## Summary

Replace the worker-pool `EmbedBatch` (N sequential HTTP calls to `/api/embeddings`) with a single HTTP call to Ollama's `/api/embed` batch endpoint.

**Before:** 6 items → 6 HTTP calls → ~18 seconds → OpenClaw plugin timeout
**After:** 6 items → 1 HTTP call → 0.5 seconds → works reliably

This fixes the `memory_store_batch` tool hanging/crashing in OpenClaw — the root cause was the embedding phase taking too long, not the Memgraph writes.

## Changes

- `internal/embedder/ollama.go`: `EmbedBatch` now sends all texts in one POST to `/api/embed` with `{"model": "...", "input": ["text1", "text2", ...]}` and receives all embeddings back in `{"embeddings": [[...], [...], ...]}`
- `tests/embedder_test.go`: Fake Ollama server updated to handle both `/api/embeddings` (single) and `/api/embed` (batch) endpoints

## Test plan

- [x] `go test -short -count=1 ./...` — all pass
- [x] Live test: 6 items stored in 0.5s via `store-batch`
- [x] `gofmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)