### PR TITLE
release: v0.7.2 — batch embed performance fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.7.2] - 2026-03-15
+
+### Fixed
+- Ollama EmbedBatch: replaced N sequential HTTP calls with single `/api/embed` batch call (36x faster — 6 items in 0.5s vs 18s)
+- Fixes `memory_store_batch` timeout in OpenClaw plugin
+
 ## [0.7.1] - 2026-03-15
 
 ### Fixed

--- a/cmd/openclaw-cortex/main.go
+++ b/cmd/openclaw-cortex/main.go
@@ -16,7 +16,7 @@ import (
 	"github.com/ajitpratap0/openclaw-cortex/internal/memgraph"
 )
 
-var version = "0.7.1"
+var version = "0.7.2"
 
 var cfg *config.Config
 

--- a/extensions/openclaw-plugin/index.ts
+++ b/extensions/openclaw-plugin/index.ts
@@ -18,7 +18,7 @@ const execFileAsync = promisify(execFile);
 
 // Plugin version — bump this when making changes to the plugin.
 // The binary also has its own version (set via ldflags at build time).
-const PLUGIN_VERSION = "0.7.1";
+const PLUGIN_VERSION = "0.7.2";
 
 // ============================================================================
 // Types

--- a/extensions/openclaw-plugin/openclaw.plugin.json
+++ b/extensions/openclaw-plugin/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "memory-cortex",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "kind": "memory",
   "configSchema": {
     "type": "object",

--- a/extensions/openclaw-plugin/package.json
+++ b/extensions/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memory-cortex",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "OpenClaw memory plugin backed by Cortex (Memgraph graph DB + multi-factor ranking)",
   "type": "module",
   "main": "index.ts",


### PR DESCRIPTION
## Summary

Version bump to v0.7.2 with the Ollama batch embed fix (PR #57).

### What's in v0.7.2
- Ollama `EmbedBatch` uses native `/api/embed` batch endpoint (1 HTTP call for N texts)
- 36x speedup: 6 items in 0.5s (was 18s)
- Fixes `memory_store_batch` timeout in OpenClaw plugin

### Version bump
- Binary, plugin, manifest, package.json: 0.7.1 → 0.7.2
- CHANGELOG entry added

After merge, tag `v0.7.2` to trigger release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)