### PR TITLE
feat: Phase 3 — Contradiction Detection (vector + keyword heuristic)

### DIFF
--- a/internal/capture/contradiction.go
+++ b/internal/capture/contradiction.go
@@ -532,3 +532,12 @@ func InvalidateContradictions(ctx context.Context, st store.Store, results []Con
 		}
 	}
 }
+
+// DetectContradictions is a convenience wrapper for simple heuristic-only contradiction detection.
+// It creates a MemoryContradictionDetector with defaults and runs FindContradictions.
+func DetectContradictions(ctx context.Context, st store.Store, _ interface{}, newMemory models.Memory, newEmbedding []float32) ([]ContradictionResult, error) {
+	cfg := DefaultContradictionConfig()
+	logger := slog.Default()
+	d := NewContradictionDetector(st, nil, nil, nil, "", cfg, logger)
+	return d.FindContradictions(ctx, newMemory.Content, newEmbedding)
+}

--- a/tests/contradiction_test.go
+++ b/tests/contradiction_test.go
@@ -66,9 +66,9 @@ func TestContradiction_WorksAt(t *testing.T) {
 
 	found := false
 	for _, h := range hits {
-		if h.MemoryID == pixisMem.ID {
+		if h.CandidateID == pixisMem.ID {
 			found = true
-			t.Logf("flagged contradiction: %s — %s", h.MemoryID, h.Reason)
+			t.Logf("flagged contradiction: %s — %s", h.CandidateID, h.Reason)
 		}
 	}
 	if !found {
@@ -78,8 +78,8 @@ func TestContradiction_WorksAt(t *testing.T) {
 	// Simulate the store pipeline: invalidate contradicted memories.
 	now := time.Now().UTC()
 	for _, h := range hits {
-		if invalidErr := st.InvalidateMemory(context.Background(), h.MemoryID, now); invalidErr != nil {
-			t.Errorf("InvalidateMemory(%s): %v", h.MemoryID, invalidErr)
+		if invalidErr := st.InvalidateMemory(context.Background(), h.CandidateID, now); invalidErr != nil {
+			t.Errorf("InvalidateMemory(%s): %v", h.CandidateID, invalidErr)
 		}
 	}
 


### PR DESCRIPTION
## Phase 3: Contradiction Detection

### What
Pure embedding similarity + keyword heuristic contradiction detector — no LLM calls.

### Files
- `internal/capture/contradiction.go`: Core detection logic
  - `DetectContradictions`: free-function API (vector search top 20, threshold 0.75 + exclusive-predicate matching)
  - `MemoryContradictionDetector`: struct implementing `store.ContradictionDetector`
  - `InvalidateContradictions`: batch-invalidates contradicted memories
  - Exclusive predicates: WORKS_AT, HAS_ROLE, LOCATED_IN, LIVES_IN, MARRIED_TO, REPORTS_TO
  
- `tests/contradiction_test.go`: 3 tests
  - `TestContradiction_WorksAt`: Ajit works at Pixis → Booking.com flags contradiction ✓
  - `TestContradiction_NoFalsePositive`: unrelated memories don't cross-fire ✓
  - `TestInvalidateMemory_SetsValidTo`: validates the store API ✓

### Algorithm
1. Vector search top N candidates (similarity ≥ 0.75)
2. For each candidate, check if both share an exclusive-predicate signal (e.g. "works at")
3. If signals match but content diverges (< 50% significant word overlap) → contradiction