### PR TITLE
feat(api): add GET /v1/recall/stream SSE endpoint

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -65,6 +65,9 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("POST /v1/search", s.auth(s.handleSearch))
 	mux.HandleFunc("GET /v1/stats", s.auth(s.handleStats))
 
+	// Streaming recall endpoint.
+	mux.HandleFunc("GET /v1/recall/stream", s.auth(s.handleRecallStream))
+
 	// Entity endpoints.
 	mux.HandleFunc("GET /v1/entities/{id}", s.auth(s.handleGetEntity))
 	mux.HandleFunc("GET /v1/entities", s.auth(s.handleSearchEntities))
@@ -558,6 +561,116 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.writeJSON(w, http.StatusOK, stats)
+}
+
+// RecallStreamEvent is a single SSE payload sent by GET /v1/recall/stream.
+type RecallStreamEvent struct {
+	Index  int           `json:"index"`
+	Memory models.Memory `json:"memory"`
+	Score  float64       `json:"score"`
+}
+
+func (s *Server) handleRecallStream(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+
+	query := q.Get("q")
+	if query == "" {
+		s.writeError(w, http.StatusBadRequest, "q is required")
+		return
+	}
+
+	project := q.Get("project")
+	userID := q.Get("user_id")
+
+	const maxStreamLimit = 50
+	limit := 10
+	if limitStr := q.Get("limit"); limitStr != "" {
+		if parsed, parseErr := strconv.Atoi(limitStr); parseErr == nil && parsed > 0 {
+			if parsed > maxStreamLimit {
+				limit = maxStreamLimit
+			} else {
+				limit = parsed
+			}
+		}
+	}
+
+	vec, err := s.embedder.Embed(r.Context(), query)
+	if err != nil {
+		s.logger.Error("handleRecallStream: embed failed", "error", err)
+		s.writeError(w, http.StatusInternalServerError, "failed to generate embedding")
+		return
+	}
+
+	var filters *store.SearchFilters
+	if project != "" || userID != "" {
+		filters = &store.SearchFilters{}
+		if project != "" {
+			proj := project
+			filters.Project = &proj
+		}
+		if userID != "" {
+			filters.UserID = userID
+		}
+	}
+
+	fetchLimit := uint64(limit * 5)
+	results, err := s.store.Search(r.Context(), vec, fetchLimit, filters)
+	if err != nil {
+		s.logger.Error("handleRecallStream: search failed", "error", err)
+		s.writeError(w, http.StatusInternalServerError, "failed to search memories")
+		return
+	}
+
+	ranked := s.recall.Rank(results, project, query)
+
+	// Trim to requested limit.
+	if len(ranked) > limit {
+		ranked = ranked[:limit]
+	}
+
+	// Set SSE headers before writing any body.
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("X-Accel-Buffering", "no")
+	w.WriteHeader(http.StatusOK)
+
+	flusher, canFlush := w.(http.Flusher)
+
+	enc := json.NewEncoder(w)
+
+	for i := range ranked {
+		evt := RecallStreamEvent{
+			Index:  i,
+			Memory: ranked[i].Memory,
+			Score:  ranked[i].FinalScore,
+		}
+
+		if _, writeErr := fmt.Fprintf(w, "data: "); writeErr != nil {
+			s.logger.Warn("handleRecallStream: write prefix failed", "error", writeErr)
+			return
+		}
+		if encErr := enc.Encode(evt); encErr != nil {
+			s.logger.Warn("handleRecallStream: encode event failed", "index", i, "error", encErr)
+			return
+		}
+		// json.Encoder.Encode appends a newline; add a second one to form SSE double-newline.
+		if _, writeErr := fmt.Fprintf(w, "\n"); writeErr != nil {
+			s.logger.Warn("handleRecallStream: write newline failed", "error", writeErr)
+			return
+		}
+
+		if canFlush {
+			flusher.Flush()
+		}
+	}
+
+	// Send [DONE] sentinel.
+	if _, writeErr := fmt.Fprintf(w, "data: [DONE]\n\n"); writeErr != nil {
+		s.logger.Warn("handleRecallStream: write done sentinel failed", "error", writeErr)
+	}
+	if canFlush {
+		flusher.Flush()
+	}
 }
 
 // --- entity handlers ---

--- a/tests/streaming_recall_test.go
+++ b/tests/streaming_recall_test.go
@@ -1,0 +1,173 @@
+package tests
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ajitpratap0/openclaw-cortex/internal/api"
+	"github.com/ajitpratap0/openclaw-cortex/internal/models"
+	"github.com/ajitpratap0/openclaw-cortex/internal/recall"
+	"github.com/ajitpratap0/openclaw-cortex/internal/store"
+)
+
+// newStreamTestServer creates a test HTTP server for streaming recall tests.
+func newStreamTestServer(t *testing.T, st *store.MockStore) *httptest.Server {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	rec := recall.NewRecaller(recall.DefaultWeights(), logger)
+	emb := &apiTestEmbedder{}
+	srv := api.NewServer(st, rec, emb, logger, "")
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// TestRecallStream_EventsOrdered verifies that GET /v1/recall/stream streams events in order
+// and terminates with a [DONE] sentinel.
+func TestRecallStream_EventsOrdered(t *testing.T) {
+	st := store.NewMockStore()
+	now := time.Now().UTC()
+
+	vec := make([]float32, 768)
+	for i := range vec {
+		vec[i] = 0.5
+	}
+
+	memories := []models.Memory{
+		{
+			ID:         "stream-mem-1",
+			Type:       models.MemoryTypeFact,
+			Scope:      models.ScopePermanent,
+			Visibility: models.VisibilityPrivate,
+			Content:    "streaming test memory one",
+			Confidence: 0.9,
+			CreatedAt:  now,
+			UpdatedAt:  now,
+		},
+		{
+			ID:         "stream-mem-2",
+			Type:       models.MemoryTypeFact,
+			Scope:      models.ScopePermanent,
+			Visibility: models.VisibilityPrivate,
+			Content:    "streaming test memory two",
+			Confidence: 0.85,
+			CreatedAt:  now,
+			UpdatedAt:  now,
+		},
+		{
+			ID:         "stream-mem-3",
+			Type:       models.MemoryTypeFact,
+			Scope:      models.ScopePermanent,
+			Visibility: models.VisibilityPrivate,
+			Content:    "streaming test memory three",
+			Confidence: 0.8,
+			CreatedAt:  now,
+			UpdatedAt:  now,
+		},
+	}
+
+	for i := range memories {
+		if err := st.Upsert(context.Background(), memories[i], vec); err != nil {
+			t.Fatalf("Upsert memory %d: %v", i, err)
+		}
+	}
+
+	ts := newStreamTestServer(t, st)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
+		ts.URL+"/v1/recall/stream?q=streaming+test", http.NoBody)
+	if err != nil {
+		t.Fatalf("creating request: %v", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET /v1/recall/stream: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	ct := resp.Header.Get("Content-Type")
+	if !strings.HasPrefix(ct, "text/event-stream") {
+		t.Errorf("expected Content-Type text/event-stream, got %q", ct)
+	}
+
+	// Parse SSE events from response body.
+	type streamEvent struct {
+		Index  int           `json:"index"`
+		Memory models.Memory `json:"memory"`
+		Score  float64       `json:"score"`
+	}
+
+	var events []streamEvent
+	var doneReceived bool
+
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		payload := strings.TrimPrefix(line, "data: ")
+		if payload == "[DONE]" {
+			doneReceived = true
+			break
+		}
+		var evt streamEvent
+		if decErr := json.Unmarshal([]byte(payload), &evt); decErr != nil {
+			t.Fatalf("unmarshal event %q: %v", payload, decErr)
+		}
+		events = append(events, evt)
+	}
+	if scanErr := scanner.Err(); scanErr != nil {
+		t.Fatalf("scanner error: %v", scanErr)
+	}
+
+	if !doneReceived {
+		t.Error("expected [DONE] sentinel but did not receive it")
+	}
+
+	if len(events) == 0 {
+		t.Fatal("expected at least one streaming event, got none")
+	}
+
+	// Verify events are received in order (Index 0, 1, 2, ...).
+	for i := range events {
+		if events[i].Index != i {
+			t.Errorf("event[%d].Index = %d, want %d", i, events[i].Index, i)
+		}
+	}
+}
+
+// TestRecallStream_MissingQuery verifies that GET /v1/recall/stream without q param returns 400.
+func TestRecallStream_MissingQuery(t *testing.T) {
+	st := store.NewMockStore()
+	ts := newStreamTestServer(t, st)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
+		ts.URL+"/v1/recall/stream", http.NoBody)
+	if err != nil {
+		t.Fatalf("creating request: %v", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET /v1/recall/stream: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+}


### PR DESCRIPTION
## Summary

- **`internal/api/server.go`**: adds `GET /v1/recall/stream` SSE endpoint with `handleRecallStream` handler
  - Query params: `q` (required), `project`, `user_id`, `limit` (default 10, max 50)
  - Embeds query → searches store (5× headroom) → ranks → streams each result as SSE event
  - SSE format: `data: <json>\n\n` per event, `data: [DONE]\n\n` sentinel at end
  - Flushes after each event; correct error handling before headers written
- **`tests/streaming_recall_test.go`**: two black-box tests
  - `TestRecallStream_EventsOrdered` — verifies 200, Content-Type, event ordering, [DONE] sentinel
  - `TestRecallStream_MissingQuery` — verifies 400 for missing `q`

Stacks on `feat/user-namespacing-b`.

## Test plan

- [ ] `go test -short -race -count=1 ./...` passes
- [ ] `TestRecallStream_EventsOrdered` — events arrive in order (Index 0, 1, 2...) with [DONE] sentinel
- [ ] `TestRecallStream_MissingQuery` — 400 response without `q` param
- [ ] `Content-Type: text/event-stream` header verified in response

🤖 Generated with [Claude Code](https://claude.com/claude-code)