### PR TITLE
fix(llm): configurable HTTP timeout + typed HTTPError for GatewayClient

### DIFF
--- a/internal/llm/gateway.go
+++ b/internal/llm/gateway.go
@@ -15,9 +15,9 @@ import (
 // GatewayClient sends completions through an OpenAI-compatible HTTP gateway.
 // It implements LLMClient.
 type GatewayClient struct {
-	baseURL string
-	token   string
-	http    *http.Client
+	baseURL    string
+	token      string
+	httpClient *http.Client
 }
 
 // NewGatewayClient creates a GatewayClient that POSTs to baseURL/v1/chat/completions
@@ -25,9 +25,9 @@ type GatewayClient struct {
 func NewGatewayClient(baseURL, token string, timeoutSeconds int) *GatewayClient {
 	timeout := time.Duration(timeoutSeconds) * time.Second
 	return &GatewayClient{
-		baseURL: baseURL,
-		token:   token,
-		http:    &http.Client{Timeout: timeout},
+		baseURL:    baseURL,
+		token:      token,
+		httpClient: &http.Client{Timeout: timeout},
 	}
 }
 
@@ -81,7 +81,7 @@ func (g *GatewayClient) Complete(ctx context.Context, model, systemPrompt, userM
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+g.token)
 
-	resp, err := g.http.Do(req)
+	resp, err := g.httpClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("gateway complete: do request: %w", err)
 	}

--- a/tests/llm_test.go
+++ b/tests/llm_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -87,6 +88,19 @@ func TestGatewayClient_Complete_ConnectionRefused(t *testing.T) {
 	client := llm.NewGatewayClient("http://127.0.0.1:1", "tok", 0)
 	_, err := client.Complete(context.Background(), "m", "sys", "usr", 100)
 	assert.Error(t, err)
+}
+
+func TestGatewayClient_Timeout(t *testing.T) {
+	// Server deliberately delays 2 seconds; client timeout is 1 second.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(2 * time.Second)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	client := llm.NewGatewayClient(srv.URL, "tok", 1) // 1s timeout
+	_, err := client.Complete(context.Background(), "m", "sys", "usr", 100)
+	require.Error(t, err)
 }
 
 // --- NewClient factory ---


### PR DESCRIPTION
## Summary

- `NewGatewayClient` now accepts a `timeoutSeconds int` parameter; `0` means no timeout (used in tests).
- `ClaudeConfig` gains `GatewayTimeoutSeconds int` (default 60s, env `OPENCLAW_CORTEX_CLAUDE_GATEWAY_TIMEOUT_SECONDS`).
- New `internal/llm/errors.go` defines `*HTTPError{StatusCode, Body}` returned on non-2xx responses, enabling `errors.As`-based status-code discrimination in callers and the future circuit breaker (Track 4).
- `tests/llm_test.go` added: both `NewGatewayClient` call-sites pass `0` as third arg to preserve no-timeout behavior against fast mock servers.

## Test plan

- [x] `TestGatewayClient_Timeout` — 1s-timeout client vs context-aware server returns error
- [x] `TestGatewayClient_NoTimeoutOnFastResponse` — 5s-timeout client vs fast server succeeds
- [x] `TestGatewayClient_HTTPErrorType` — 429 response returns `*llm.HTTPError` unwrappable via `errors.As` with correct `StatusCode`
- [x] All pre-existing `TestGatewayClient_Complete_*` and `TestNewClient_*` tests remain green
- [x] `go test -short -race -count=1 ./...` passes
- [x] `golangci-lint run ./...` passes (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)