### PR TITLE
fix(api): auth gate, per-IP rate limiting, TLS flags

### DIFF
--- a/cmd/openclaw-cortex/cmd_serve.go
+++ b/cmd/openclaw-cortex/cmd_serve.go
@@ -32,6 +32,10 @@ func serveCmd() *cobra.Command {
 				logger.Warn("HTTP API: auth is DISABLED (--unsafe-no-auth); do not expose this port")
 			}
 
+			if (tlsCert == "") != (tlsKey == "") {
+				return fmt.Errorf("serve: --tls-cert and --tls-key must both be set or both be empty")
+			}
+
 			emb := newEmbedder(logger)
 			st, err := newMemgraphStore(ctx, logger)
 			if err != nil {
@@ -47,7 +51,7 @@ func serveCmd() *cobra.Command {
 
 			srv := api.NewServer(st, rec, emb, logger, cfg.API.AuthToken, cfg.API.CursorSecret)
 
-			rl := api.RateLimitMiddleware(cfg.API.RateLimitRPS, cfg.API.RateLimitBurst)
+			rl := api.RateLimitMiddleware(ctx, cfg.API.RateLimitRPS, cfg.API.RateLimitBurst)
 			httpSrv := &http.Server{
 				Addr:              cfg.API.ListenAddr,
 				Handler:           rl(srv.Handler()),

--- a/internal/api/ratelimit.go
+++ b/internal/api/ratelimit.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"net/http"
 	"strings"
 	"sync"
@@ -18,8 +19,9 @@ var exemptPaths = map[string]bool{
 // RateLimitMiddleware returns per-IP token bucket middleware.
 // rps is the sustained rate (requests per second); burst is the bucket capacity.
 // Each unique client IP gets its own limiter. Visitors not seen for 3 minutes
-// are purged from the in-memory map by a background goroutine.
-func RateLimitMiddleware(rps float64, burst int) func(http.Handler) http.Handler {
+// are purged from the in-memory map by a background goroutine that exits when
+// ctx is canceled.
+func RateLimitMiddleware(ctx context.Context, rps float64, burst int) func(http.Handler) http.Handler {
 	type visitor struct {
 		limiter  *rate.Limiter
 		lastSeen time.Time
@@ -31,17 +33,24 @@ func RateLimitMiddleware(rps float64, burst int) func(http.Handler) http.Handler
 	)
 
 	// Background goroutine purges stale visitors every minute to prevent
-	// unbounded memory growth in long-running servers.
+	// unbounded memory growth in long-running servers. It exits when ctx is
+	// canceled so the goroutine does not leak after server shutdown.
 	go func() {
+		ticker := time.NewTicker(time.Minute)
+		defer ticker.Stop()
 		for {
-			time.Sleep(time.Minute)
-			mu.Lock()
-			for ip, v := range visitors {
-				if time.Since(v.lastSeen) > 3*time.Minute {
-					delete(visitors, ip)
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				mu.Lock()
+				for ip, v := range visitors {
+					if time.Since(v.lastSeen) > 3*time.Minute {
+						delete(visitors, ip)
+					}
 				}
+				mu.Unlock()
 			}
-			mu.Unlock()
 		}
 	}()
 

--- a/tests/api_ratelimit_test.go
+++ b/tests/api_ratelimit_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"os/exec"
@@ -14,7 +15,7 @@ import (
 // TestRateLimitMiddleware_AllowsUnderLimit verifies that requests well below
 // the burst capacity all receive 200 OK.
 func TestRateLimitMiddleware_AllowsUnderLimit(t *testing.T) {
-	handler := api.RateLimitMiddleware(10, 10)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := api.RateLimitMiddleware(context.Background(), 10, 10)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	req := httptest.NewRequest(http.MethodGet, "/v1/recall", nil)
@@ -34,7 +35,7 @@ func TestRateLimitMiddleware_AllowsUnderLimit(t *testing.T) {
 // rps=1, burst=2: after 2 immediate requests the bucket is empty; the third
 // (and beyond) must receive 429.
 func TestRateLimitMiddleware_Returns429OnBurst(t *testing.T) {
-	handler := api.RateLimitMiddleware(1, 2)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := api.RateLimitMiddleware(context.Background(), 1, 2)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	req := httptest.NewRequest(http.MethodGet, "/v1/recall", nil)
@@ -59,7 +60,7 @@ func TestRateLimitMiddleware_Returns429OnBurst(t *testing.T) {
 func TestRateLimitMiddleware_ExemptPaths(t *testing.T) {
 	// rps=0.001, burst=1 — essentially a closed limiter.
 	// Any non-exempt path would 429 immediately after the first request.
-	handler := api.RateLimitMiddleware(0.001, 1)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := api.RateLimitMiddleware(context.Background(), 0.001, 1)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
@@ -85,7 +86,7 @@ func TestRateLimitMiddleware_ExemptPaths(t *testing.T) {
 // TestRateLimitMiddleware_PerIPIsolation verifies that two different IPs have
 // independent token buckets — exhausting one does not affect the other.
 func TestRateLimitMiddleware_PerIPIsolation(t *testing.T) {
-	handler := api.RateLimitMiddleware(1, 2)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := api.RateLimitMiddleware(context.Background(), 1, 2)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
@@ -111,7 +112,7 @@ func TestRateLimitMiddleware_PerIPIsolation(t *testing.T) {
 func TestRateLimitMiddleware_429ResponseBody(t *testing.T) {
 	// rps=0, burst=0 is not valid for the token bucket; use rps=1, burst=1
 	// and fire 3 immediate requests so the second/third will be 429.
-	handler := api.RateLimitMiddleware(1, 1)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := api.RateLimitMiddleware(context.Background(), 1, 1)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	req := httptest.NewRequest(http.MethodPost, "/v1/remember", nil)


### PR DESCRIPTION
## Summary

- **Auth gate**: `serve` now hard-fails on startup when `api.auth_token` is empty unless `--unsafe-no-auth` is explicitly passed, preventing accidental unauthenticated exposure in production
- **Per-IP rate limiting**: `RateLimitMiddleware` wraps the server handler with token-bucket rate limiting (default 100 RPS, burst 20, configurable via `api.rate_limit_rps` / `api.rate_limit_burst`); `/healthz` and `/metrics` are exempt; stale visitor entries are purged every 3 minutes
- **TLS flags**: `--tls-cert` and `--tls-key` flags enable `ListenAndServeTLS` without code changes

## Config

| Field | Env var | Default |
|-------|---------|---------|
| `api.rate_limit_rps` | `OPENCLAW_CORTEX_API_RATE_LIMIT_RPS` | `100` |
| `api.rate_limit_burst` | `OPENCLAW_CORTEX_API_RATE_LIMIT_BURST` | `20` |

## Test plan

- [ ] `TestRateLimitMiddleware_AllowsUnderLimit` — 5 req with burst=10 → all 200
- [ ] `TestRateLimitMiddleware_Returns429OnBurst` — 3 immediate req with rps=1, burst=2 → 3rd is 429
- [ ] `TestRateLimitMiddleware_ExemptPaths` — `/healthz` and `/metrics` bypass limiter
- [ ] `TestServeCmd_FlagsRegistered` — `serve --help` contains `--unsafe-no-auth`, `--tls-cert`, `--tls-key`

🤖 Generated with [Claude Code](https://claude.com/claude-code)