### PR TITLE
fix(health): test LLM credentials with a real ping call

### DIFF
--- a/cmd/openclaw-cortex/cmd_health.go
+++ b/cmd/openclaw-cortex/cmd_health.go
@@ -26,6 +26,29 @@ type healthResult struct {
 	Skipped  []string          `json:"skipped,omitempty"`
 }
 
+// boolPtr returns a pointer to b. Used for the three-state LLM field in
+// healthResult where nil means "not checked", true means healthy, false means failed.
+func boolPtr(b bool) *bool { return &b }
+
+// applyLLMPingResult records a ping result into result.LLM and result.Errors.
+// errPrefix is prepended to the error (e.g. "gateway ping failed"); pass ""
+// to use the error message verbatim. A nil err sets LLM=true.
+func applyLLMPingResult(result *healthResult, err error, errPrefix string) {
+	if err == nil {
+		result.LLM = boolPtr(true)
+		return
+	}
+	result.LLM = boolPtr(false)
+	if result.Errors == nil {
+		result.Errors = make(map[string]string)
+	}
+	if errPrefix == "" {
+		result.Errors["llm"] = err.Error()
+	} else {
+		result.Errors["llm"] = fmt.Sprintf("%s: %v", errPrefix, err)
+	}
+}
+
 func healthCmd() *cobra.Command {
 	var skipLLMPing bool
 	cmd := &cobra.Command{
@@ -71,7 +94,9 @@ func healthCmd() *cobra.Command {
 			}
 
 			// Check Claude LLM access: actually test the credentials with a cheap ping.
-			noCredsConfigured := cfg.Claude.GatewayURL == "" && cfg.Claude.GatewayToken == "" && cfg.Claude.APIKey == ""
+			// hasGatewayCreds mirrors the gateway case condition in the switch below.
+			hasGatewayCreds := cfg.Claude.GatewayURL != "" && cfg.Claude.GatewayToken != ""
+			noCredsConfigured := !hasGatewayCreds && cfg.Claude.APIKey == ""
 			if skipLLMPing && !noCredsConfigured {
 				// Credentials present — skip the network ping only (avoids billing).
 				// result.LLM remains nil (not checked); excluded from the OK gate.

--- a/cmd/openclaw-cortex/helpers.go
+++ b/cmd/openclaw-cortex/helpers.go
@@ -76,27 +76,3 @@ func parseTags(tagsStr string) []string {
 	}
 	return parts
 }
-
-// boolPtr returns a pointer to b. Used for *bool fields in health check results
-// where nil means "not checked", true means healthy, and false means failed.
-func boolPtr(b bool) *bool { return &b }
-
-// applyLLMPingResult sets result.LLM and result.Errors based on a ping error.
-// errPrefix is prepended to the error message (e.g. "gateway ping failed").
-// If err is nil the ping succeeded and LLM is set to true.
-// If errPrefix is empty the error message is used verbatim.
-func applyLLMPingResult(result *healthResult, err error, errPrefix string) {
-	if err == nil {
-		result.LLM = boolPtr(true)
-		return
-	}
-	result.LLM = boolPtr(false)
-	if result.Errors == nil {
-		result.Errors = make(map[string]string)
-	}
-	if errPrefix == "" {
-		result.Errors["llm"] = err.Error()
-	} else {
-		result.Errors["llm"] = fmt.Sprintf("%s: %v", errPrefix, err)
-	}
-}

--- a/tests/health_llm_ping_test.go
+++ b/tests/health_llm_ping_test.go
@@ -111,20 +111,33 @@ func TestHealthLLMPing_GatewayContextTimeout(t *testing.T) {
 	require.Error(t, err, "timed-out context should return an error")
 }
 
-// TestNewClient_NoCredentials_FactoryReturnsNil verifies that llm.NewClient (the
+// TestNewClient_NoCredentials_FactoryContract verifies that llm.NewClient (the
 // factory wrapper) returns nil when no credentials are configured.
 //
 // Note: healthCmd does NOT call llm.NewClient. The no-credentials path in
 // healthCmd is the default: branch of the switch in cmd_health.go, which calls
-// applyLLMPingResult directly with a synthetic error. This test covers the
-// factory's nil-return contract independently of the health command.
+// applyLLMPingResult directly with a synthetic error. This test covers only the
+// factory's nil-return contract; see TestSkipLLMPing_NoCredentials for the
+// health-command no-credentials behavior.
 //
 // AnthropicClient coverage note: AnthropicClient.Complete calls the Anthropic SDK
 // directly (no HTTP interceptor is possible at test time), so its error path is
 // covered by integration testing only. The gateway path is fully unit-tested above.
-func TestNewClient_NoCredentials_FactoryReturnsNil(t *testing.T) {
+func TestNewClient_NoCredentials_FactoryContract(t *testing.T) {
 	client := llm.NewClient(config.ClaudeConfig{})
 	assert.Nil(t, client, "no credentials should produce a nil client")
+}
+
+// TestSkipLLMPing_NoCredentials verifies the health-command contract when
+// --skip-llm-ping is passed but no credentials are configured.
+//
+// When no credentials are present, healthCmd falls through to the default: branch
+// regardless of the flag and calls applyLLMPingResult with a synthetic error,
+// setting LLM=&false. health.LLMHealthOK must return false so overall result.OK
+// propagates as FAIL — preventing a silent pass on misconfigured nodes.
+func TestSkipLLMPing_NoCredentials(t *testing.T) {
+	f := false // value applyLLMPingResult writes when no credentials are configured
+	assert.False(t, health.LLMHealthOK(&f), "--skip-llm-ping with no credentials must mark LLM as failed")
 }
 
 // TestLLMOKGate_NoCredentialsPath verifies that health.LLMHealthOK returns false


### PR DESCRIPTION
## Summary

- The `health` command previously reported `Claude LLM: OK` whenever an API key or gateway token was present in config, without ever making an actual API call.
- An invalid or expired gateway token (e.g. a 401 Unauthorized) would silently pass the health check — the root cause of issue #97.
- This PR fixes that by issuing a cheap test completion (5 max tokens, 5-second context timeout) and surfacing any error in both the human-readable and JSON output.

### Changes

- **`cmd/openclaw-cortex/cmd_health.go`**: Replace config-presence check with an actual `Complete` call via `llm.NewGatewayClient` (gateway path) or `llm.NewAnthropicClient` (API key path). Uses `context.WithTimeout(ctx, 5s)` to keep the health check fast. Human-readable output now uses `result.LLM` rather than re-checking config, so errors are consistently reported.
- **`tests/health_llm_ping_test.go`**: Five new black-box tests in `tests/` that verify the gateway client's behavior under success, 401 Unauthorized, 403 Forbidden, context cancellation, and missing credentials.

## Test plan

- [x] `go test -short -count=1 ./...` passes
- [x] `golangci-lint run ./...` reports 0 issues
- [x] `TestHealthLLMPing_GatewayOK` — valid token, server returns 200 → no error
- [x] `TestHealthLLMPing_GatewayUnauthorized` — server returns 401 → `HTTPError{StatusCode: 401}`
- [x] `TestHealthLLMPing_GatewayForbidden` — server returns 403 → `HTTPError{StatusCode: 403}`
- [x] `TestHealthLLMPing_GatewayContextTimeout` — pre-canceled context → error propagated
- [x] `TestHealthLLMPing_NoCredentials_NilClient` — no creds → nil client → health marks FAIL

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)